### PR TITLE
Fix names and spelling of ESA centres

### DIFF
--- a/country_parent_child.tsv
+++ b/country_parent_child.tsv
@@ -5534,14 +5534,14 @@ Slovenia		A04636	SASA	Slovenian Academy of Sciences and Arts
 Slovenia	A04636	A04637	IJS	Jozef Stefan Institute, Ljubljana
 France		A04638	ESA	European Space Agency, Paris, France
 Spain	A04638	A04639	CAB Madrid	Center for Astrobiology, Madrid
-Germany	A04638	A04640	ESOC	European Space Operations Center, Darmstadt
-Netherlands	A04638	A04641	ESTEC	European Space Research and Technology Centre
-Germany	A04638	A04642	ESAC	European Science and Astronomy Center
-Germany	A04638	A04643	EAC Cologne	European Astronaut Center, Cologne
+Germany	A04638	A04640	ESOC	European Space Operations Centre, Darmstadt
+Netherlands	A04638	A04641	ESTEC	European Space Research and Technology Centre, Noordwijk
+Spain	A04638	A04642	ESAC	European Space Astronomy Centre, Villanueva de la Canada
+Germany	A04638	A04643	EAC 	European Astronaut Centre, Cologne
 Norway	A04638	A11300	NSC	Norwegian Space Center
 Spain	A04638	A11321	MDSCC	Madrid Deep Space Communication
 Spain	A04638	A11324	LAEFF	Laboratory for Space Astrophysics and Theoretical Physics
-Italy	A04638	A11376	ESRIN	European Space Research Institute
+Italy	A04638	A11376	ESRIN	European Space Research Institute, Frascati
 Italy	A04638	A11397	ASDC	ASI Science Data Center
 USA	A04638	A13114	ESA Office	Space Telescope Science Institute, ESA Office, Baltimore, Maryland
 Greece		A04644	Hellenic Open U	Hellenic Open University, Greece

--- a/parent_child.tsv
+++ b/parent_child.tsv
@@ -5587,14 +5587,14 @@ A04619	A04622	NRC Egypt	National Research Centre, Egypt
 A04636	A04637	IJS	Jozef Stefan Institute, Ljubljana
 0	A04638	ESA	European Space Agency, Paris, France
 A04638	A04639	CAB Madrid	Center for Astrobiology, Madrid
-A04638	A04640	ESOC	European Space Operations Center, Darmstadt
-A04638	A04641	ESTEC	European Space Research and Technology Centre
-A04638	A04642	ESAC	European Science and Astronomy Center
-A04638	A04643	EAC Cologne	European Astronaut Center, Cologne
+A04638	A04640	ESOC	European Space Operations Centre, Darmstadt
+A04638	A04641	ESTEC	European Space Research and Technology Centre, Noordwijk
+A04638	A04642	ESAC	European Space Astronomy Centre, Villanueva de la Canada
+A04638	A04643	EAC Cologne	European Astronaut Centre, Cologne
 A04638	A11300	NSC	Norwegian Space Center
 A04638	A11321	MDSCC	Madrid Deep Space Communication
 A04638	A11324	LAEFF	Laboratory for Space Astrophysics and Theoretical Physics
-A04638	A11376	ESRIN	European Space Research Institute
+A04638	A11376	ESRIN	European Space Research Institute, Frascati
 A04638	A11397	ASDC	ASI Science Data Center
 A04638	A13114	ESA Office	Space Telescope Science Institute, ESA Office, Baltimore, Maryland
 0	A04644	Hellenic Open U	Hellenic Open University, Greece


### PR DESCRIPTION
This pull request introduces minor changes in some ESA-related affiliations. The most important one is that ESAC stands for "European Space Astronomy Centre" and is located in Spain.
I also homogenised the British English spelling of "Centre" and added the town names for consistency.

I note that ESRIN (child_id=A11376) is listed twice with different parent_ids (A04792 and A04638).